### PR TITLE
Fix analysis error

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -17,7 +17,7 @@ analyzer:
     - ios/**
     - lib/sentence/sentence.g.dart
     - lib/sentence/sentence.freezed.dart
-    - lib/sentence/sentence_state.freezed.dart
+    - lib/sentence/sentence_collection.freezed.dart
     - lib/story/story.g.dart
     - lib/story/story.freezed.dart
 linter:


### PR DESCRIPTION
## why
- analysis_optionsの設定忘れ
  - freezedのファイルをexcludeし忘れてwarningでanalyzeに引っかかってしまう


## what
- freezedのファイルをexclude