### PR TITLE
MessageとFirestoreオブジェクトの変換時の型エラーの修正

### DIFF
--- a/lib/user_question_chat/models/message.g.dart
+++ b/lib/user_question_chat/models/message.g.dart
@@ -10,9 +10,7 @@ _$_Message _$_$_MessageFromJson(Map<String, dynamic> json) {
   return _$_Message(
     username: json['username'] as String,
     body: json['body'] as String,
-    createdDate: json['createdDate'] == null
-        ? null
-        : DateTime.parse(json['createdDate'] as String),
+    createdDate: json['createdDate'] as DateTime,
   );
 }
 


### PR DESCRIPTION
## why
Freezedで再生成したコードを修正するのを忘れていたため、MessageとFirestoreオブジェクトの変換時の型エラーが起こっていた


## what
message.g.dart修正