### PR TITLE
Providerのバージョンアップに伴うバグの修正

### DIFF
--- a/lib/novel/widgets/novel_game_character_image.dart
+++ b/lib/novel/widgets/novel_game_character_image.dart
@@ -7,11 +7,12 @@ import 'package:provider/provider.dart';
 class NovelGameCharacterImage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
+    final currentCharecterImagePath = context
+        .select<SentenceCollection, String>((s) => s.currentCharecterImagePath);
+    final zoomLevel = context.select<SentenceCollection, String>(
+        (s) => s.currentCharecterImageEffect);
     return Center(child: Builder(
       builder: (_) {
-        final currentCharecterImagePath =
-            context.select<SentenceCollection, String>(
-                (s) => s.currentCharecterImagePath);
         if (currentCharecterImagePath ==
             'assets/character_images/ypose_hokuma.png') {
           return Container(
@@ -19,17 +20,14 @@ class NovelGameCharacterImage extends StatelessWidget {
             height: double.infinity,
             child: VTweetAnimationContainer(
               child: ZoomedCharacterImageContainer(
-                charecterImagePath: currentCharecterImagePath,
-                zoomLevel: context.select<SentenceCollection, String>(
-                    (s) => s.currentCharecterImageEffect),
-              ),
+                  charecterImagePath: currentCharecterImagePath,
+                  zoomLevel: zoomLevel),
             ),
           );
         }
         return ZoomedCharacterImageContainer(
           charecterImagePath: currentCharecterImagePath,
-          zoomLevel: context.select<SentenceCollection, String>(
-              (s) => s.currentCharecterImageEffect),
+          zoomLevel: zoomLevel,
         );
       },
     ));

--- a/lib/story/widgets/story_details_body.dart
+++ b/lib/story/widgets/story_details_body.dart
@@ -7,6 +7,7 @@ import 'package:provider/provider.dart';
 class StoryDetailsBody extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
+    final storyId = context.select<Story, int>((s) => s.id);
     return Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
       const SizedBox(height: 50),
       Text(
@@ -44,7 +45,7 @@ class StoryDetailsBody extends StatelessWidget {
               MaterialPageRoute(
                 builder: (_) {
                   return NovelGamePage(
-                    storyId: context.select<Story, int>((s) => s.id),
+                    storyId: storyId,
                   );
                 },
               ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,21 +7,21 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.0"
+    version: "4.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.39.8"
+    version: "0.39.10"
   args:
     dependency: transitive
     description:
       name: args
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.2"
+    version: "1.6.0"
   async:
     dependency: transitive
     description:
@@ -119,7 +119,7 @@ packages:
       name: code_builder
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.2.1"
+    version: "3.3.0"
   collection:
     dependency: transitive
     description:
@@ -140,14 +140,14 @@ packages:
       name: coverage
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.13.9"
+    version: "0.14.0"
   crypto:
     dependency: transitive
     description:
       name: crypto
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.3"
+    version: "2.1.5"
   csslib:
     dependency: transitive
     description:
@@ -218,7 +218,7 @@ packages:
       name: freezed
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.10.7"
+    version: "0.10.9"
   freezed_annotation:
     dependency: "direct main"
     description:
@@ -288,7 +288,7 @@ packages:
       name: js
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.1+1"
+    version: "0.6.2"
   json_annotation:
     dependency: transitive
     description:
@@ -358,21 +358,21 @@ packages:
       name: node_interop
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.3"
+    version: "1.1.1"
   node_io:
     dependency: transitive
     description:
       name: node_io
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1+2"
+    version: "1.1.1"
   node_preamble:
     dependency: transitive
     description:
       name: node_preamble
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.8"
+    version: "1.4.12"
   package_config:
     dependency: transitive
     description:
@@ -380,13 +380,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.9.3"
-  package_resolver:
-    dependency: transitive
-    description:
-      name: package_resolver
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.10"
   path:
     dependency: transitive
     description:
@@ -400,7 +393,14 @@ packages:
       name: pedantic
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0+1"
+    version: "1.9.0"
+  platform_detect:
+    dependency: transitive
+    description:
+      name: platform_detect
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.4.0"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -421,7 +421,7 @@ packages:
       name: provider
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.1.0-dev"
+    version: "4.1.3"
   pub_semver:
     dependency: transitive
     description:
@@ -442,7 +442,7 @@ packages:
       name: quiver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.5"
+    version: "2.1.3"
   selectable_autolink_text:
     dependency: "direct main"
     description:
@@ -456,14 +456,14 @@ packages:
       name: shelf
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.7.5"
+    version: "0.7.7"
   shelf_packages_handler:
     dependency: transitive
     description:
       name: shelf_packages_handler
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.4"
+    version: "2.0.0"
   shelf_static:
     dependency: transitive
     description:
@@ -594,28 +594,28 @@ packages:
       name: url_launcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.4.5"
+    version: "5.4.11"
   url_launcher_macos:
     dependency: transitive
     description:
       name: url_launcher_macos
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.0.1+5"
+    version: "0.0.1+7"
   url_launcher_platform_interface:
     dependency: transitive
     description:
       name: url_launcher_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.6"
+    version: "1.0.7"
   url_launcher_web:
     dependency: "direct main"
     description:
       name: url_launcher_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.1+2"
+    version: "0.1.1+6"
   vector_math:
     dependency: transitive
     description:
@@ -629,7 +629,7 @@ packages:
       name: vm_service
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.1"
+    version: "4.1.0"
   watcher:
     dependency: transitive
     description:
@@ -650,7 +650,7 @@ packages:
       name: webkit_inspection_protocol
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.5.3"
+    version: "0.7.3"
   yaml:
     dependency: transitive
     description:
@@ -660,4 +660,4 @@ packages:
     version: "2.2.1"
 sdks:
   dart: ">=2.7.0 <3.0.0"
-  flutter: ">=1.12.13+hotfix.5 <2.0.0"
+  flutter: ">=1.16.0 <2.0.0"


### PR DESCRIPTION
## why
- Provideのバージョンをあげたら、context.selectがbuildメソッド内以外では使えなくなった


## what
- buildメソッド内だけでcontext.selectを呼ぶように変更
  - onPressedやBuilderの中でcontext.selectを使わないようにしたとも言える
- Providerバージョンアップ
  - version: "4.1.0-dev" -> version: "4.1.3"
  - ついでに他のパッケージも更新