### PR TITLE
Providerをちゃんと使う

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,7 @@ import 'package:firebase/firebase.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_state_management/app.dart';
 import 'package:flutter_state_management/story/models/story_api.dart';
+import 'package:flutter_state_management/user_question_chat/models/user_question_chat_api.dart';
 import 'package:provider/provider.dart';
 
 void main() {
@@ -17,5 +18,13 @@ void main() {
 
   analytics(firebaseApp);
 
-  runApp(Provider(create: (_) => StoryApi(), child: RootApp()));
+  runApp(
+    MultiProvider(
+      providers: [
+        storyApiProvider,
+        userQuestionChatApiProvider,
+      ],
+      child: RootApp(),
+    ),
+  );
 }

--- a/lib/sentence/models/sentence_collection_controller.dart
+++ b/lib/sentence/models/sentence_collection_controller.dart
@@ -9,12 +9,13 @@ class SentenceCollectionContoller extends StateNotifier<SentenceCollection>
   SentenceCollectionContoller({@required this.storyId}) : super(null);
 
   final int storyId;
+  StoryApi get _apiClient => read();
 
   @override
   Future<void> initState() async {
     try {
       final sentenceList =
-          await StoryApi().getStorySentenceList(storyId.toString());
+          await _apiClient.getStorySentenceList(storyId.toString());
       state = SentenceCollection(sentenceIndex: 0, sentenceList: sentenceList);
     } on Exception {
       state = SentenceCollection(sentenceIndex: 0, sentenceList: [

--- a/lib/story/models/story_api.dart
+++ b/lib/story/models/story_api.dart
@@ -1,6 +1,7 @@
 import 'package:firebase/firebase.dart' as fb;
 import 'package:flutter_state_management/sentence/models/sentence.dart';
 import 'package:flutter_state_management/story/models/story.dart';
+import 'package:provider/provider.dart';
 
 class StoryApi {
   Stream<List<Story>> getStoryList() {
@@ -32,3 +33,7 @@ class StoryApi {
     }
   }
 }
+
+final storyApiProvider = Provider(
+  create: (_) => StoryApi(),
+);

--- a/lib/story/widgets/story_list.dart
+++ b/lib/story/widgets/story_list.dart
@@ -10,7 +10,7 @@ class StoryList extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return StreamBuilder(
-        stream: StoryApi().getStoryList(),
+        stream: Provider.of<StoryApi>(context, listen: false).getStoryList(),
         builder: (context, AsyncSnapshot<dynamic> snapshot) {
           if (!snapshot.hasData) {
             return const Center(child: CircularProgressIndicator());

--- a/lib/user_question_chat/models/user_question_chat_api.dart
+++ b/lib/user_question_chat/models/user_question_chat_api.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:firebase/firebase.dart' as fb;
 import 'package:firebase/firestore.dart';
 import 'package:flutter_state_management/user_question_chat/models/message.dart';
+import 'package:provider/provider.dart';
 
 class UserQuestionChatApi {
   Future<bool> post({String username, String body}) async {
@@ -35,3 +36,7 @@ class UserQuestionChatApi {
     }
   }
 }
+
+final userQuestionChatApiProvider = Provider(
+  create: (_) => UserQuestionChatApi(),
+);


### PR DESCRIPTION
## why
- StoryAPIを複数の場所でインスタンス化していた

## what
- Providerを使って一つのインスタンスを使うように変更
- ProviderをAPIクライアントと同じファイルに定義（Riverpod風）