### PR TITLE
VTweenAnimationContainerのdispose忘れ修正

### DIFF
--- a/lib/novel/widgets/novel_game_character_image.dart
+++ b/lib/novel/widgets/novel_game_character_image.dart
@@ -18,7 +18,7 @@ class NovelGameCharacterImage extends StatelessWidget {
           return Container(
             width: double.infinity,
             height: double.infinity,
-            child: VTweetAnimationContainer(
+            child: VTweenAnimationContainer(
               child: ZoomedCharacterImageContainer(
                   charecterImagePath: currentCharecterImagePath,
                   zoomLevel: zoomLevel),

--- a/lib/novel/widgets/v_tween_animation_container.dart
+++ b/lib/novel/widgets/v_tween_animation_container.dart
@@ -1,19 +1,19 @@
 import 'package:flutter/material.dart';
 import 'package:meta/meta.dart';
 
-class VTweetAnimationContainer extends StatefulWidget {
-  const VTweetAnimationContainer({@required this.child});
+class VTweenAnimationContainer extends StatefulWidget {
+  const VTweenAnimationContainer({@required this.child});
 
   final Widget child;
 
   @override
-  _VTweetAnimationContainerState createState() =>
-      _VTweetAnimationContainerState(child: child);
+  _VTweenAnimationContainerState createState() =>
+      _VTweenAnimationContainerState(child: child);
 }
 
-class _VTweetAnimationContainerState extends State<VTweetAnimationContainer>
+class _VTweenAnimationContainerState extends State<VTweenAnimationContainer>
     with TickerProviderStateMixin {
-  _VTweetAnimationContainerState({@required this.child});
+  _VTweenAnimationContainerState({@required this.child});
 
   final Widget child;
   AnimationController controller;

--- a/lib/novel/widgets/v_tween_animation_container.dart
+++ b/lib/novel/widgets/v_tween_animation_container.dart
@@ -60,4 +60,11 @@ class _VTweetAnimationContainerState extends State<VTweetAnimationContainer>
   Widget build(BuildContext context) {
     return AlignTransition(alignment: animation, child: child);
   }
+
+  @override
+  void dispose() {
+    super.dispose();
+    controller.dispose();
+    controller2.dispose();
+  }
 }


### PR DESCRIPTION
## why
- VTweenAnimationContainerのdispose()でsuper.dispose()を読んでおらず、warningが出ていた


## what
- VTweenAnimationContainerのdispose()でsuper.dispose()を呼ぶように修正
  - dispose()でanimation controllerもdisposeするように修正
- typo修正