### PR TITLE
Improve build_runner performance

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,0 +1,19 @@
+targets:
+  $default:
+    builders:
+      freezed:
+        generate_for:
+          include:
+            - lib/user_question_chat/models/message.dart
+            - lib/story/models/story.dart
+            - lib/sentence/models/sentence.dart
+            - lib/sentence/models/sentence_collection.dart
+      json_serializable:
+        generate_for:
+          include:
+            - lib/user_question_chat/models/message.dart
+            - lib/story/models/story.dart
+            - lib/sentence/models/sentence.dart
+        options:
+          any_map: true
+          explicit_to_json: true


### PR DESCRIPTION
## why
- freezed、json_serializableのコード生成に時間がかかっていて短縮したい


## what
- build.yaml で freezed、json_serializableに対しての生成元を絞る設定をすることで生成時間を短縮した

## 参考
https://twitter.com/_mono/status/1284299309647724544?s=20